### PR TITLE
Feature/css compilation improvement

### DIFF
--- a/config/themes.json.sample
+++ b/config/themes.json.sample
@@ -27,6 +27,7 @@
     "stylesDir": "web/css",
     "postcss": ["plugins.autoprefixer()"],
     "disableSuffix": true,
+    "skipBuild": true,
     "modules": {
       "Snowdog_Sample": "vendor/snowdog/module-sample"
     },

--- a/task/styles.js
+++ b/task/styles.js
@@ -14,7 +14,9 @@ module.exports = function() { // eslint-disable-line func-names
 
   // Loop through themes to compile scss or less depending on your config.json
   themes.forEach(name => {
-    streams.add(require('../helper/scss')(gulp, plugins, config, name));
+    if (!config.themes[name].skipBuild && (plugins.util.env.theme == name || !plugins.util.env.theme)) {
+      streams.add(require('../helper/scss')(gulp, plugins, config, name));
+    }
   });
 
   return streams;


### PR DESCRIPTION
This adds two new features

- `skipBuild` themes.json parameter which will not build that theme's CSS. Useful for skipping bb2 when compiling child themes
- ability to pass `--theme=bb2` to specifically compile only one theme within the themes.json config