### PR TITLE
Update to use gulp4-run-sequence

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,14 +3,14 @@
 const plugins = require('gulp-load-plugins')({
     pattern: ['*', '!gulp', '!gulp-load-plugins'],
     rename : {
-      'browser-sync'    : 'browserSync',
-      'fs-extra'        : 'fs',
-      'gulp-multi-dest' : 'multiDest',
-      'js-yaml'         : 'yaml',
-      'marked-terminal' : 'markedTerminal',
-      'merge-stream'    : 'mergeStream',
-      'postcss-reporter': 'reporter',
-      'run-sequence'    : 'runSequence'
+      'browser-sync'      : 'browserSync',
+      'fs-extra'          : 'fs',
+      'gulp-multi-dest'   : 'multiDest',
+      'js-yaml'           : 'yaml',
+      'marked-terminal'   : 'markedTerminal',
+      'merge-stream'      : 'mergeStream',
+      'postcss-reporter'  : 'reporter',
+      'gulp4-run-sequence': 'runSequence'
     }
   }),
   config = {};

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "postcss-inline-svg": "^3.0.0",
     "postcss-object-fit-images": "^1.1.2",
     "postcss-reporter": "~3.0.0",
-    "run-sequence": "~1.2.2",
+    "gulp4-run-sequence": "~1.0.1",
     "stylelint": "~7.10.1",
     "stylelint-config-standard": "~16.0.0"
   },


### PR DESCRIPTION
Fixes CW 415577

Update frontools to use gulp4-run-sequence because run-sequence is not compatible with node 14
